### PR TITLE
Amplification and 0-RTT

### DIFF
--- a/draft-bormann-core-corr-clar.md
+++ b/draft-bormann-core-corr-clar.md
@@ -528,10 +528,10 @@ If it is not certain that the request is not a replay,
 but the request handler is safe
 and there is no risk of metadata revealing data,
 the server can answer the request.
-Metadata that can reveal data are the size of the response
+Kinds of metadata to look out for are the size of the response
 (which, in a replay situation, can give an active attacker additional data)
 as well as any processing delays.
-(There should be no observable side effects for safe or previously processed idempotent requests).
+(Side effects would also fall into that category, but there should not be any effects for safe requests).
 
 If nothing else, GET requests to constant resources,
 such as queries to /.well-known/core,

--- a/draft-bormann-core-corr-clar.md
+++ b/draft-bormann-core-corr-clar.md
@@ -490,24 +490,34 @@ issue include:
 
 ## RFC 7252-9.1/11.3: Handling outdated addresses and security contexts {#amp-0rtt}
 
+INCOMPLETE:
+: Tools for mitigating these scenarios were unavailable when specified, and are now explained.
+
+PENDING.
+
 Established security contexts and established return addresses can become obsolete.
 For example, this happens when a DTLS session is resumed via CIDs, when the client's IP address changes, or when the replay window of an OSCORE context is lost and recovered through the mechanism of [Appendix B.1.2 of RFC8613].
 In those situations, a server still needs to maintain its security and and amplification mitigation properties,
-which are generally independent but can be addressed using the same tools.
+which are generally independent topics but can be addressed using the same tools.
 
-A safe option is always to reject the initial request and request confirmation,
-eg. using CoAP's mechanism of sending a 4.01 (Unauthorized) response with an Echo option
-(where a subsequent request with the same Echo value proves to the server that the destination was reachable).
-It is RECOMMENDED to use the Echo mechanism for interoperability.
-A more security mechanism specific tool such as RRC ({{?I-D.ietf-tls-dtls-rrc}} may be used instead,
-but the peer may or may not support that extension.
+A safe option is always to reject the initial request and request confirmation.
+The RECOMMENDED way to do that is using CoAP's mechanism of sending a 4.01 (Unauthorized) response with an Echo option
+(where a subsequent request with the same Echo value proves to the server that the destination was reachable);
+clients SHOULD act to the Echo option as specified in {{?RFC9175}}.
+Tools specific to a security mechanism such as RRC ({{?I-D.ietf-tls-dtls-rrc}} may be used instead,
+but their use may depend on successful negotiation.
+
+### Amplification mitigation and return routability
 
 If it is not certain that the client is reachable on the request's sender address,
 but the response does not exceed the request's size by a factor of 3 ({{Section 2.4 of RFC9175}}, item 3),
 the server can answer the request.
 It should still include an Echo value, whose presence in the next request serves to confirm the client's address.
+
 This situation can happen at any time in OSCORE,
 or in DTLS after a CID based resumption.
+
+### Replay protection
 
 If it is not certain that the request is not a replay,
 but the request handler is safe or long-term idempotent
@@ -517,10 +527,12 @@ Metadata that can reveal data are the size of the response
 (which, in a replay situation, can give an active attacker additional data)
 as well as any processing delays.
 (There should be no observable side effects for safe or previously processed idempotent requests).
+
 Assessing whether a resource is long-term idempotent is not always trivial, and it is prudent to err at the side of caution.
 If nothing else, GET requests to constant resources,
 such as queries to /.well-known/core,
 can often be responded to safely on the CoAP layer even without any replay protection.
+
 This situation can happen in OSCORE after a partial loss of context.
 It can currently not happen in DTLS because 0-RTT Data is not allowed for CoAP (cf. {{Section 14 of ?I-D.ietf-uta-tls13-iot-profile-09}})
 at the time of writing

--- a/draft-bormann-core-corr-clar.md
+++ b/draft-bormann-core-corr-clar.md
@@ -488,6 +488,39 @@ issue include:
 * <https://github.com/core-wg/corrclar/issues/9>\\
 ("Clarify/revise language around epochs in section 9.1.1 #9")
 
+## RFC 7252-9.1/11.3: Handling outdated addresses and security contexts {#amp-0rtt}
+
+Established security contexts and established return addresses can become obsolete.
+For example, this happens when a DTLS session is resumed via CIDs, when the client's IP address changes, or when the replay window of an OSCORE context is lost and recovered through the mechanism of [Appendix B.1.2 of RFC8613].
+In those situations, a server still needs to maintain its security and and amplification mitigation properties,
+which are generally independent but can be addressed using the same tools.
+
+A safe option is always to reject the initial request and request confirmation,
+either using CoAP's mechanism of sending a 4.01 (Unauthorized) response with an Echo option
+(where a subsequent request with the same Echo value proves to the server that the destination was reachable)
+or by using a more security mechanism specific tool such as RRC ({{?I-D.ietf-tls-dtls-rrc}}.
+
+If it is not certain that the client is reachable on the request's sender address,
+but the response does not exceed the request's size by a factor of 3 ({{Section 2.4 of RFC9175}}, item 3),
+the server can answer the request.
+It should still include an Echo value, whose presence in the next request serves to confirm the client's address.
+
+If it is not certain that the request is not a replay,
+but the request handler is safe or long-term idempotent
+and there is no risk of metadata revealing data,
+the server can answer the request.
+Metadata that can reveal data are the size of the response
+(which, in a replay situation, can give an active attacker additional data)
+as well as any processing delays.
+(There should be no observable side effects for safe or previously processed idempotent requests).
+Assessing whether a resource is long-term idempotent is not always trivial, and it is prudent to err at the side of caution.
+If nothing else, GET requests to constant resources,
+such as queries to /.well-known/core,
+can often be responded to safely on the CoAP layer even without any replay protection.
+
+Implementors of OSCORE beware answering potential replays is only safe from the CoAP application's point of view.
+As always, unless the sender sequence number of the request has just been removed from a correctly initialized replay window,
+the response can not reuse the request's nonce, but needs to take an own sequence number from the server's space.
 
 ## RFC 7252-12.3: Content-Format Registry {#ct}
 

--- a/draft-bormann-core-corr-clar.md
+++ b/draft-bormann-core-corr-clar.md
@@ -540,7 +540,7 @@ can often be responded to safely on the CoAP layer even without any replay prote
 There are resources for which more requests than those with safe codes may be handled without replay protection,
 but as that assessment is hard to make, it is prudent to err at the side of caution.
 
-This situation can happen in OSCORE after a partial loss of context.
+Uncertainty about whether a request might be a replay can happen in OSCORE after a partial loss of context.
 Currently, this cannot happen in DTLS because 0-RTT Data is not allowed for CoAP (cf. {{Section 14 of ?I-D.ietf-uta-tls13-iot-profile-09}}). However, that may change if a future document defines a profile for using early data with CoAP.
 
 Implementers of OSCORE should be aware that answering potential replays is only safe from the CoAP application's point of view.

--- a/draft-bormann-core-corr-clar.md
+++ b/draft-bormann-core-corr-clar.md
@@ -525,7 +525,7 @@ RRC provides the right tools to make it.
 ### Replay protection
 
 If it is not certain that the request is not a replay,
-but the request handler is safe or long-term idempotent
+but the request handler is safe
 and there is no risk of metadata revealing data,
 the server can answer the request.
 Metadata that can reveal data are the size of the response
@@ -533,10 +533,12 @@ Metadata that can reveal data are the size of the response
 as well as any processing delays.
 (There should be no observable side effects for safe or previously processed idempotent requests).
 
-Assessing whether a resource is long-term idempotent is not always trivial, and it is prudent to err at the side of caution.
 If nothing else, GET requests to constant resources,
 such as queries to /.well-known/core,
 can often be responded to safely on the CoAP layer even without any replay protection.
+
+There are resources for which more requests than those with safe codes may be handled without replay protection,
+but as that assessment is hard to make, it is prudent to err at the side of caution.
 
 This situation can happen in OSCORE after a partial loss of context.
 Currently, this cannot happen in DTLS because 0-RTT Data is not allowed for CoAP (cf. {{Section 14 of ?I-D.ietf-uta-tls13-iot-profile-09}}). However, that may change if a future document defines a profile for using early data with CoAP.

--- a/draft-bormann-core-corr-clar.md
+++ b/draft-bormann-core-corr-clar.md
@@ -517,6 +517,16 @@ It should still include an Echo value, whose presence in the next request serves
 This situation can happen at any time in OSCORE,
 or in DTLS after a CID based resumption.
 
+Verifying the client's address is not only relevant for amplification attacks
+(which addresses attacks described in {{?I-D.irtf-t2trg-amplification-attacks}})
+but also for traffic misdirection.
+{{Section 7 of ?I-D.ietf-tls-dtls-rrc}} contains a menu of options how to use RRC messages to distinguish different cases.
+An 4.01 response with Echo can perform some of the functions equivalently
+(with the Echo value taking the place of the RRC cookie),
+but does not provide a means to distinguish between non-preferred and preferred paths.
+Where that distinction matters,
+RRC provides the right tools to make it.
+
 ### Replay protection
 
 If it is not certain that the request is not a replay,

--- a/draft-bormann-core-corr-clar.md
+++ b/draft-bormann-core-corr-clar.md
@@ -496,14 +496,18 @@ In those situations, a server still needs to maintain its security and and ampli
 which are generally independent but can be addressed using the same tools.
 
 A safe option is always to reject the initial request and request confirmation,
-either using CoAP's mechanism of sending a 4.01 (Unauthorized) response with an Echo option
-(where a subsequent request with the same Echo value proves to the server that the destination was reachable)
-or by using a more security mechanism specific tool such as RRC ({{?I-D.ietf-tls-dtls-rrc}}.
+eg. using CoAP's mechanism of sending a 4.01 (Unauthorized) response with an Echo option
+(where a subsequent request with the same Echo value proves to the server that the destination was reachable).
+It is RECOMMENDED to use the Echo mechanism for interoperability.
+A more security mechanism specific tool such as RRC ({{?I-D.ietf-tls-dtls-rrc}} may be used instead,
+but the peer may or may not support that extension.
 
 If it is not certain that the client is reachable on the request's sender address,
 but the response does not exceed the request's size by a factor of 3 ({{Section 2.4 of RFC9175}}, item 3),
 the server can answer the request.
 It should still include an Echo value, whose presence in the next request serves to confirm the client's address.
+This situation can happen at any time in OSCORE,
+or in DTLS after a CID based resumption.
 
 If it is not certain that the request is not a replay,
 but the request handler is safe or long-term idempotent
@@ -517,6 +521,10 @@ Assessing whether a resource is long-term idempotent is not always trivial, and 
 If nothing else, GET requests to constant resources,
 such as queries to /.well-known/core,
 can often be responded to safely on the CoAP layer even without any replay protection.
+This situation can happen in OSCORE after a partial loss of context.
+It can currently not happen in DTLS because 0-RTT Data is not allowed for CoAP (cf. {{Section 14 of ?I-D.ietf-uta-tls13-iot-profile-09}})
+at the time of writing
+(but that may change with a future document).
 
 Implementors of OSCORE beware answering potential replays is only safe from the CoAP application's point of view.
 As always, unless the sender sequence number of the request has just been removed from a correctly initialized replay window,

--- a/draft-bormann-core-corr-clar.md
+++ b/draft-bormann-core-corr-clar.md
@@ -497,15 +497,14 @@ PENDING.
 
 Established security contexts and established return addresses can become obsolete.
 For example, this happens when a DTLS session is resumed via CIDs, when the client's IP address changes, or when the replay window of an OSCORE context is lost and recovered through the mechanism of [Appendix B.1.2 of RFC8613].
-In those situations, a server still needs to maintain its security and and amplification mitigation properties,
-which are generally independent topics but can be addressed using the same tools.
+In those situations, a server still needs to maintain its security and amplification mitigation properties,
+which are generally independent concerns but can be addressed using the same tools.
 
 A safe option is always to reject the initial request and request confirmation.
 The RECOMMENDED way to do that is using CoAP's mechanism of sending a 4.01 (Unauthorized) response with an Echo option
 (where a subsequent request with the same Echo value proves to the server that the destination was reachable);
 clients SHOULD act to the Echo option as specified in {{?RFC9175}}.
-Tools specific to a security mechanism such as RRC ({{?I-D.ietf-tls-dtls-rrc}} may be used instead,
-but their use may depend on successful negotiation.
+Tools specific to a security protocol, such as RRC ({{?I-D.ietf-tls-dtls-rrc}}) in case of DTLS, may be used. However, their use may depend on successful negotiation.
 
 ### Amplification mitigation and return routability
 
@@ -514,16 +513,12 @@ but the response does not exceed the request's size by a factor of 3 ({{Section 
 the server can answer the request.
 It should still include an Echo value, whose presence in the next request serves to confirm the client's address.
 
-This situation can happen at any time in OSCORE,
-or in DTLS after a CID based resumption.
+This situation can happen at any time, especially after a prolonged period of quiescence, regardless of the security protocol.
 
-Verifying the client's address is not only relevant for amplification attacks
-(which addresses attacks described in {{?I-D.irtf-t2trg-amplification-attacks}})
-but also for traffic misdirection.
-{{Section 7 of ?I-D.ietf-tls-dtls-rrc}} contains a menu of options how to use RRC messages to distinguish different cases.
-An 4.01 response with Echo can perform some of the functions equivalently
-(with the Echo value taking the place of the RRC cookie),
-but does not provide a means to distinguish between non-preferred and preferred paths.
+Verifying the client's address is not only crucial for mitigating amplification attacks ({{?I-D.irtf-t2trg-amplification-attacks}}), but also to avoid traffic misdirection.
+{{Section 7 of ?I-D.ietf-tls-dtls-rrc}} describes options for how to use RRC messages to distinguish different cases.
+A 4.01 response with Echo can perform some of the same functions, with the Echo value replacing the RRC cookie. However, it does not offer a way to distinguish between non-preferred and preferred paths.
+
 Where that distinction matters,
 RRC provides the right tools to make it.
 
@@ -544,11 +539,9 @@ such as queries to /.well-known/core,
 can often be responded to safely on the CoAP layer even without any replay protection.
 
 This situation can happen in OSCORE after a partial loss of context.
-It can currently not happen in DTLS because 0-RTT Data is not allowed for CoAP (cf. {{Section 14 of ?I-D.ietf-uta-tls13-iot-profile-09}})
-at the time of writing
-(but that may change with a future document).
+Currently, this cannot happen in DTLS because 0-RTT Data is not allowed for CoAP (cf. {{Section 14 of ?I-D.ietf-uta-tls13-iot-profile-09}}). However, that may change if a future document defines a profile for using early data with CoAP.
 
-Implementors of OSCORE beware answering potential replays is only safe from the CoAP application's point of view.
+Implementers of OSCORE should be aware that answering potential replays is only safe from the CoAP application's point of view.
 As always, unless the sender sequence number of the request has just been removed from a correctly initialized replay window,
 the response can not reuse the request's nonce, but needs to take an own sequence number from the server's space.
 

--- a/draft-ietf-core-corr-clar.md
+++ b/draft-ietf-core-corr-clar.md
@@ -491,7 +491,7 @@ issue include:
 ## RFC 7252-9.1/11.3: Handling outdated addresses and security contexts {#amp-0rtt}
 
 INCOMPLETE:
-: Tools for mitigating these scenarios were unavailable when specified, and are now explained.
+: Tools for mitigating these scenarios were unavailable when CoAP was specified, and are now explained.
 
 PENDING.
 
@@ -566,7 +566,7 @@ as well as any processing delays.
 If nothing else, GET requests to constant resources,
 such as queries to /.well-known/core,
 can often be responded to safely on the CoAP layer even without any replay protection.
-There are resources for which more requests than those with safe codes may be handled without replay protection,
+There are resources for which more requests than those with safe methods may be handled without replay protection,
 but as that assessment is hard to make, it is prudent to err at the side of caution.
 
 CoAP has no error code like HTTP's 425 Too Early with which a server could ask the client to resubmit its request later
@@ -579,7 +579,7 @@ Exceeding what is described there, a server can safely send a successful respons
 provided its criteria for 0RTT responses are met.
 The server can still send an Echo option with the successful response:
 Only when the client repeats that Echo value in a subsequent response can the replay window be initialized.
-Implementers of OSCORE should be aware that answering potential replays is only safe from the CoAP application's point of view.
+Implementers of OSCORE should be aware that answering potential replays can only be determined to be safe from the CoAP application's point of view.
 As always, unless the sequence number in the request has just been removed from an initialized replay window,
 the response can not reuse the request's nonce, but needs to be sent with a new sequence number from the server's space.
 

--- a/draft-ietf-core-corr-clar.md
+++ b/draft-ietf-core-corr-clar.md
@@ -496,7 +496,7 @@ INCOMPLETE:
 PENDING.
 
 Established security contexts and established return addresses can become obsolete.
-For example, this happens when a DTLS session is resumed via CIDs, when the client's IP address changes, or when the replay window of an OSCORE context is lost and recovered through the mechanism of [Appendix B.1.2 of RFC8613].
+For example, this happens when a DTLS session is continued via CIDs, when the client's IP address changes, or when the replay window of an OSCORE context is lost and recovered through the mechanism of [Appendix B.1.2 of RFC8613].
 In those situations, a server still needs to maintain its security and amplification mitigation properties,
 which are generally independent concerns but can be addressed using the same tools.
 

--- a/draft-ietf-core-corr-clar.md
+++ b/draft-ietf-core-corr-clar.md
@@ -544,8 +544,8 @@ Uncertainty about whether a request might be a replay can happen in OSCORE after
 Currently, this cannot happen in DTLS because 0-RTT Data is not allowed for CoAP (cf. {{Section 14 of ?I-D.ietf-uta-tls13-iot-profile-09}}). However, that may change if a future document defines a profile for using early data with CoAP.
 
 Implementers of OSCORE should be aware that answering potential replays is only safe from the CoAP application's point of view.
-As always, unless the sender sequence number of the request has just been removed from a correctly initialized replay window,
-the response can not reuse the request's nonce, but needs to take an own sequence number from the server's space.
+As always, unless the sequence number in the request has just been removed from an initialized replay window,
+the response can not reuse the request's nonce, but needs to be sent with a new sequence number from the server's space.
 
 ## RFC 7252-12.3: Content-Format Registry {#ct}
 

--- a/draft-ietf-core-corr-clar.md
+++ b/draft-ietf-core-corr-clar.md
@@ -495,11 +495,20 @@ INCOMPLETE:
 
 PENDING.
 
-Established security contexts and established return addresses can become obsolete.
-For example, this happens when a DTLS session is continued via CIDs, when the client's IP address changes, or when the replay window of an OSCORE context is lost and recovered through the mechanism of [Appendix B.1.2 of RFC8613].
-In those situations, a server still needs to maintain its security and amplification mitigation properties,
-which are generally independent concerns but can be addressed using the same tools.
+Information obtained about an established communication partner can experience continuity interruptions
+and become obsolete.
+This can happen on different levels:
+For example,
+return routability information is lost when client's IP address changes,
+and information about whether a request was already handled can be lost when an OSCORE context is recovered as described in its [Appendix B.1.2 of RFC8613].
+No matter the cause of the loss, a server still needs to maintain its security and amplification mitigation properties.
 
+The concerns addressed in the following subsections are independent on a specification level,
+but are described together because they can be addressed with the same tools --
+moreover, a single round trip of using Echo in a response can address both at the same time.
+In some scenarios, these are even expected to coincide.
+
+(move)
 A safe option is always to reject the initial request and request confirmation.
 The RECOMMENDED way to do that is using CoAP's mechanism of sending a 4.01 (Unauthorized) response with an Echo option
 (where a subsequent request with the same Echo value proves to the server that the destination was reachable);
@@ -508,11 +517,22 @@ Tools specific to a security protocol, such as RRC ({{?I-D.ietf-tls-dtls-rrc}}) 
 
 ### Amplification mitigation and return routability
 
-If it is not certain that the client is reachable on the request's sender address,
-but the response does not exceed the request's size by a factor of 3 ({{Section 2.4 of RFC9175}}, item 3),
-the server can answer the request.
-It should still include an Echo value, whose presence in the next request serves to confirm the client's address.
+CoAP servers have to mitigate the effects of traffic amplification
+as required in {{Section 11.3 of RFC7252}};
+the maximum acceptable amplification factor of 3 is now the IETF consensus
+reflected for CoAP in {{Section 2.4 of RFC9175}},
+which can be summarized for this application as follows:
 
+If the server has learned that the client is reachable on the request's sender address,
+it can send a response.
+Otherwise, if the response does not exceed the request's size by a factor of 3 ({{Section 2.4 of RFC9175}}, item 3),
+the server can answer the request successfully, but should still include an Echo value,
+whose presence in the next request serves to confirm the client's address.
+Otherwise, a 4.01 (Unautorized) error response with an Echo value is sent.
+
+Address verification is triggered
+both for new clients
+and for existing clients that changed their address.
 This situation can happen at any time, especially after a prolonged period of quiescence, regardless of the security protocol.
 
 Verifying the client's address is not only crucial for mitigating amplification attacks ({{?I-D.irtf-t2trg-amplification-attacks}}), but also to avoid traffic misdirection.
@@ -522,12 +542,22 @@ A 4.01 response with Echo can perform some of the same functions, with the Echo 
 Where that distinction matters,
 RRC provides the right tools to make it.
 
+<!-- maybe compare Echo to HelloRetryRequest from 9147? -->
+
 ### Replay protection
 
-If it is not certain that the request is not a replay,
-but the request handler is safe
-and there is no risk of metadata revealing data,
-the server can answer the request.
+Security mechanisms can offer trade-offs between performance and the security properties freshness and replay protection.
+They sometimes use names such as "0RTT" (zero round-trip time).
+With those mechanisms, the server recognizes that a request is sent in such a 0RTT mode,
+but can still decide to send a response.
+The general trade-off is that an attacker may intercept such a message
+and replay it at any later time, possibly multiple times,
+without the server having a relibale way of recognizing the replay.
+
+The semantics of CoAP are conducive to using such facilities:
+Safe requests are recognized by their code to not have side effects.
+Nonetheless, more aspects need to be considered:
+There is no risk of metadata revealing data if the server answers a request multiple times.
 Kinds of metadata to look out for are the size of the response
 (which, in a replay situation, can give an active attacker additional data)
 as well as any processing delays.
@@ -536,16 +566,25 @@ as well as any processing delays.
 If nothing else, GET requests to constant resources,
 such as queries to /.well-known/core,
 can often be responded to safely on the CoAP layer even without any replay protection.
-
 There are resources for which more requests than those with safe codes may be handled without replay protection,
 but as that assessment is hard to make, it is prudent to err at the side of caution.
 
-Uncertainty about whether a request might be a replay can happen in OSCORE after a partial loss of context.
-Currently, this cannot happen in DTLS because 0-RTT Data is not allowed for CoAP (cf. {{Section 14 of ?I-D.ietf-uta-tls13-iot-profile-09}}). However, that may change if a future document defines a profile for using early data with CoAP.
+CoAP has no error code like HTTP's 425 Too Early with which a server could ask the client to resubmit its request later
+when all the security mechanism's guarantees are available.
+Instead, servers can send 4.01 Unauthorized responses with Echo option;
+clients then repeat the request with the Echo value in the request.
 
+[Appendix B.1.2 of RFC8613] describes how this is used to recover loss of state in OSCORE.
+Exceeding what is described there, a server can safely send a successful response,
+provided its criteria for 0RTT responses are met.
+The server can still send an Echo option with the successful response:
+Only when the client repeats that Echo value in a subsequent response can the replay window be initialized.
 Implementers of OSCORE should be aware that answering potential replays is only safe from the CoAP application's point of view.
 As always, unless the sequence number in the request has just been removed from an initialized replay window,
 the response can not reuse the request's nonce, but needs to be sent with a new sequence number from the server's space.
+
+Requests with 0RTT properties can currently not happen in DTLS because 0-RTT Data is not allowed for CoAP (cf. {{Section 14 of ?I-D.ietf-uta-tls13-iot-profile-09}}). However, that may change if a future document defines a profile for using early data with CoAP.
+
 
 ## RFC 7252-12.3: Content-Format Registry {#ct}
 


### PR DESCRIPTION
This adds text I suggested in #39 to close it.

Compared to the text discussed there, it also takes up the TBD item of covering the advanced return routability strategies (mainly by saying "apply what you can or just use RRC"). Unlike envisioned there I did *not* say that that doesn't work on OSCORE, because as long as it's all about flipping NATs and attacks sending the response through the old address *will* work, but I don't want to waste time on IPv4 stuff, and it kind of feels off to counter an attack by doing layering violations (sending the OSCORE response to the old address is one, as it affects the underlying CoAP layer). If there is a need to ensure that there are no proxies on an OSCORE hop (or that all are known), I'd rather discuss how to do that once-and-for-all than by probing around at address change time.

Slightly differently from the interim discussion the text is *not* marked as "this will go away", because it's more offering criteria for when a 0RTT response is good than saying that it can be done over DTLS (so it now only contains an unspec reference to whichever document will say that it *is* allowed, and that document can then defer to corrclar for criteria or take the text, depending on preferences and timelines).

CC'ing @boaks as per @thomas-fossati's suggestion